### PR TITLE
Add experiment instructions box to simulation UI

### DIFF
--- a/experiment/simulation/index.html
+++ b/experiment/simulation/index.html
@@ -29,6 +29,23 @@
 </head>
 
 <body>
+        <!-- Instruction Box -->
+    <div class="instruction-box">
+        <h2 class="instruction-title">📋 Experiment Instructions</h2>
+        <div class="instruction-content">
+            <p><strong>Objective:</strong> Interface DHT11 sensor with ESP32 and send temperature & humidity data to ThingSpeak cloud platform using HTTP protocol.</p>
+            <ol>
+<li>Review the ESP32 code for WiFi credentials, ThingSpeak API key, and DHT11 sensor configuration.</li>
+<li>Understand the code flow including WiFi connection, sensor initialization, and HTTP GET request creation.</li>
+<li>Click <strong>"Start Simulation"</strong> to initiate WiFi connection and send sensor data to the ThingSpeak cloud.</li>
+<li>Observe temperature and humidity readings from the DHT11 sensor being transmitted at regular intervals.</li>
+<li>Scroll down to view the <strong>ThingSpeak Cloud Dashboard</strong> with live data, real-time graphs, and updated timestamps.</li>
+<li>Click <strong>"Stop Simulation"</strong> to terminate the connection and stop data transmission.</li>
+
+            </ol>
+            <p class="note">💡 <strong>Note:</strong> ThingSpeak allows data updates every 15 seconds. The ESP32 sends data to Channel 2454420 using HTTP GET with API Key authentication.</p>
+        </div>
+    </div>
 
   <div class="container">
     <div class="box" style="border: none;">

--- a/experiment/simulation/src/css/style2.css
+++ b/experiment/simulation/src/css/style2.css
@@ -33,6 +33,58 @@ body {
   top: 0vh;  
 } 
 
+/* Instruction Box Styles */
+.instruction-box {
+  width: 90vw;
+  margin: 20px auto;
+  padding: 20px 30px;
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  border: 2px solid #4a90e2;
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.instruction-title {
+  color: #2c3e50;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 24px;
+  margin: 0 0 15px 0;
+  text-align: center;
+}
+
+.instruction-content {
+  font-family: Arial, Helvetica, sans-serif;
+  color: #34495e;
+  line-height: 1.6;
+}
+
+.instruction-content p {
+  margin: 10px 0;
+}
+
+.instruction-content ol {
+  margin: 15px 0;
+  padding-left: 25px;
+}
+
+.instruction-content ol li {
+  margin: 8px 0;
+  font-size: 16px;
+}
+
+.instruction-content .note {
+  background-color: #fff3cd;
+  border-left: 4px solid #ffc107;
+  padding: 10px 15px;
+  margin-top: 15px;
+  border-radius: 4px;
+}
+
+.instruction-content strong {
+  color: #2c3e50;
+  font-weight: 600;
+}
+
   .container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Introduced an instruction box in index.html to guide users through the DHT11-ESP32-ThingSpeak experiment. Added corresponding CSS styles in style2.css for improved visual presentation and clarity.